### PR TITLE
SHIP-3308 Library function to find the appropriate binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/composer.phar
+/composer.lock
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,19 @@
       "email": "erick@shipearly.com"
     },
     {
+      "name": "Aron Schmidt",
+      "email": "aron.schmidt@shipearly.com"
+    },
+    {
       "name": "ShipEarly",
       "role": "Developer"
     }
   ],
+  "autoload": {
+    "files": [
+      "src/functions.php"
+    ]
+  },
   "minimum-stability": "stable",
   "bin": [
     "binaries/amd64/wkhtmltopdf_0.12.5_darwin_osx",
@@ -24,5 +33,7 @@
     "binaries/amd64/wkhtmltopdf_0.12.5_linux_ubuntu_xenial",
     "binaries/amd64/wkhtmltopdf_0.12.6_linux_ubuntu_jammy"
   ],
-  "require": {}
+  "require": {
+    "php": ">=7.0"
+  }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ShipEarly\Wkhtmltopdf;
+
+if (!function_exists(__NAMESPACE__ . '\get_wkhtmltopdf_bin')) {
+    /**
+     * @return string get path to wkhtmltopdf bin
+     */
+    function get_wkhtmltopdf_bin(): string
+    {
+        $OS = parse_ini_file('/etc/os-release');
+        $ROOT = dirname(__FILE__, 2);
+        $dir = $ROOT . '/binaries/amd64';
+
+        // Production uses the alpine binary
+        $bin = 'wkhtmltopdf_0.12.5_linux_alpine_3.13';
+
+        // Dev environments are assumed to run ubuntu
+        if ($OS['ID'] === 'ubuntu') {
+            // The latest ubuntu binary also works on versions beyond Jammy 22.04 so far.
+            $bin = 'wkhtmltopdf_0.12.6_linux_ubuntu_jammy';
+
+            if (version_compare($OS['VERSION_ID'], '22.04', '<')) {
+                $legacy_bin = "wkhtmltopdf_0.12.5_linux_ubuntu_{$OS['VERSION_CODENAME']}";
+                if (file_exists($dir . '/' . $legacy_bin)) {
+                    $bin = $legacy_bin;
+                }
+            }
+        }
+
+        return $dir . '/' . $bin;
+    }
+}

--- a/test/functions.php
+++ b/test/functions.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * No framework. Just a script that can be run directly to sanity check the functions.
+ *
+ * Eg. Run from project root:
+ *
+ * ```
+ * php test/functions.php
+ * ```
+ */
+
+namespace ShipEarly\Wkhtmltopdf\Test;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$filename = \ShipEarly\Wkhtmltopdf\get_wkhtmltopdf_bin();
+print_r([
+    'os' => parse_ini_file('/etc/os-release'),
+    'filename' => $filename,
+    'exists' => file_exists($filename) ? 'yes' : 'no',
+]);


### PR DESCRIPTION
Move the binary file selection logic from `get_wkhtmltopdf_bin()` of the main ShipEarly app project to this project, so that any future changes to the set of binaries, such as a version update, and the matching change to the selection logic is encapsulated in this project.

- Copy `get_wkhtmltopdf_bin()` to a PHP source file in this project.
- Include the source file in the composer autoload listing so that it can be imported to replace `get_wkhtmltopdf_bin()` in the main project.
- Namespace the function so that it is not imported as a pure global.